### PR TITLE
Add Park Forum Healthcare landing page

### DIFF
--- a/forumhealth/index.html
+++ b/forumhealth/index.html
@@ -708,7 +708,7 @@
 
             <!-- Hero Graphic -->
             <div class="pulse-graphic">
-                <img src="BP-Nashville-Banner_1920x1080px (1).jpg" alt="Bitcoin Park Nashville" class="hero-banner-img">
+                <img src="../BP-Nashville-Banner_1920x1080px (1).jpg" alt="Bitcoin Park Nashville" class="hero-banner-img">
             </div>
 
             <p class="hero-eyebrow">Bitcoin Park Presents</p>


### PR DESCRIPTION
## Summary
- Adds new `forumhealth/index.html` landing page for the Park Forum: The Case for Bitcoin in Healthcare event (April 8, 2026)
- Modeled after the Grassroots Bitcoin page with healthcare-specific visual identity: Bitcoin orange, deep navy, and clinical white palette
- Sections: hero with BP Nashville banner, about/theme callout, topics grid, who's invited, and register CTA

## Test plan
- [ ] Visit `/forumhealth` and verify page renders correctly
- [ ] Check all nav links and Register CTA point to the correct Zaprite payment URL
- [ ] Verify hero image loads from `../BP-Nashville-Banner_1920x1080px (1).jpg`
- [ ] Confirm responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)