### PR TITLE
Remove Core Theme callout and info cards from About section

### DIFF
--- a/forumhealth/index.html
+++ b/forumhealth/index.html
@@ -853,26 +853,6 @@
                 <p>Hosted in the spirit of Bitcoin Park experiences, this gathering centers on the transformative theme of sound health through sound money, and how Bitcoin can address the systemic inefficiencies of fiat-driven healthcare.</p>
             </div>
 
-            <div class="theme-callout fade-in">
-                <div class="callout-label">Core Theme</div>
-                <h3>The Vital Signs of Sound Money</h3>
-                <p>Just as physicians monitor vital signs to assess patient health, Bitcoin provides the vital signs of a healthy monetary system: transparency, predictability, and stability. From direct primary care and self-funded insurance models to Bitcoin-denominated HSAs and longevity-focused care, Bitcoin stands as both a unit of account and a cornerstone of health sovereignty.</p>
-            </div>
-
-            <div class="info-cards fade-in">
-                <div class="info-card">
-                    <h3>Diagnose</h3>
-                    <p>Identify the root causes of fiat-driven dysfunction in healthcare economics, from opaque pricing to misaligned incentives and unsustainable costs.</p>
-                </div>
-                <div class="info-card">
-                    <h3>Connect</h3>
-                    <p>Build relationships across medicine, finance, and policy. Meet the practitioners and innovators leading the shift to Bitcoin-native healthcare models.</p>
-                </div>
-                <div class="info-card">
-                    <h3>Heal</h3>
-                    <p>Take home actionable frameworks for integrating Bitcoin into your practice, personal finances, and patient care, starting today.</p>
-                </div>
-            </div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Removed "The Vital Signs of Sound Money" callout box
- Removed Diagnose, Connect, and Heal info cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)