### PR TITLE
Fix mobile sponsor logos to match desktop proportions

### DIFF
--- a/forumhealth/index.html
+++ b/forumhealth/index.html
@@ -746,10 +746,10 @@
             .stats-row { gap: 36px; }
             .cta-section { padding: 80px 20px; }
             .cta-button { padding: 16px 40px; font-size: 1rem; }
-            .sponsors-logos { margin-top: 6px; overflow: hidden; }
-            .sponsor-logo { height: auto; width: 90%; max-width: 340px; transform: scale(1.5); transform-origin: center center; }
-            .sponsor-logo-unchained { height: 80px; width: auto; max-width: none; transform: none; }
-            .sponsor-logo-ten31 { height: 65px; width: auto; max-width: none; transform: none; }
+            .sponsors-logos { margin-top: 6px; gap: 24px; }
+            .sponsor-logo { height: 143px; width: auto; transform: none; }
+            .sponsor-logo-unchained { height: 27px; width: auto; max-width: none; transform: none; }
+            .sponsor-logo-ten31 { height: 101px; width: auto; max-width: none; transform: none; }
             .sponsors-hero { margin-bottom: 24px; }
         }
 
@@ -806,10 +806,10 @@
             .navbar a[href="#topics"],
             .navbar a[href="#schedule"] { display: none; }
             .pulse-graphic { max-width: 320px; width: 92%; }
-            .sponsor-logo { height: 100px; }
-            .sponsor-logo-unchained { height: 20px; }
-            .sponsor-logo-ten31 { height: 33px; }
-            .sponsors-logos { margin-top: 4px; }
+            .sponsor-logo { height: 110px; width: auto; }
+            .sponsor-logo-unchained { height: 21px; }
+            .sponsor-logo-ten31 { height: 78px; }
+            .sponsors-logos { margin-top: 4px; gap: 16px; }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- Removes the `scale(1.5)` transform hack that was causing uneven logo sizing on mobile
- Replaces with clean proportional height scaling: 65% of desktop at 768px, 50% at 480px
- All three logos (Sound HSA, Unchained, Ten31) now maintain the same visual ratios on mobile as on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)