### PR TITLE
Add Grassroots 2026 schedule page

### DIFF
--- a/grassroots/26.html
+++ b/grassroots/26.html
@@ -699,6 +699,7 @@
             <a href="#top">Home</a>
             <a href="#what">About</a>
             <a href="#who">Who's Invited</a>
+            <a href="/grassroots/schedule">Schedule</a>
             <a href="https://bitcoinpark.com/grassroots" target="_blank" rel="noopener noreferrer" class="nav-cta">Apply</a>
         </div>
     </nav>

--- a/grassroots/schedule.html
+++ b/grassroots/schedule.html
@@ -1,0 +1,850 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Schedule - Grassroots Bitcoin 2026 - Bitcoin Park</title>
+    <meta name="description" content="Schedule for Grassroots Bitcoin 2026 - April 1-2 in Nashville, Tennessee.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Montserrat:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --cream: #FAF3E8;
+            --cream-dark: #F0E6D3;
+            --terracotta: #C96B3C;
+            --terracotta-light: #E08A5A;
+            --terracotta-dark: #A85530;
+            --burnt-orange: #D4713B;
+            --dark-green: #1B3A1A;
+            --forest-green: #2D5A2B;
+            --soft-green: #4A7A48;
+            --gold: #D4A843;
+            --gold-light: #E8C76A;
+            --warm-brown: #8B6D4E;
+            --text-dark: #2C1810;
+            --text-body: #4A3728;
+            --text-light: #7A6555;
+            --white: #FFFFFF;
+            --glow-orange: rgba(201, 107, 60, 0.4);
+            --glow-green: rgba(45, 90, 43, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html {
+            scroll-behavior: smooth;
+        }
+
+        body {
+            font-family: 'Montserrat', 'Helvetica Neue', Arial, sans-serif;
+            background: var(--cream);
+            color: var(--text-body);
+            line-height: 1.6;
+            overflow-x: hidden;
+        }
+
+        /* Navbar */
+        .navbar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: rgba(250, 243, 232, 0.92);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            padding: 18px 0;
+            z-index: 1000;
+            border-bottom: 1px solid rgba(201, 107, 60, 0.15);
+            transition: all 0.3s ease;
+        }
+
+        .navbar.scrolled {
+            padding: 12px 0;
+            box-shadow: 0 4px 30px rgba(139, 109, 78, 0.1);
+        }
+
+        .navbar-content {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 40px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 36px;
+            flex-wrap: wrap;
+        }
+
+        .navbar a {
+            color: var(--text-dark);
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            transition: all 0.3s ease;
+            padding: 8px 16px;
+            border-radius: 8px;
+            font-family: 'Space Grotesk', sans-serif;
+        }
+
+        .navbar a:hover {
+            color: var(--terracotta);
+            background: rgba(201, 107, 60, 0.08);
+        }
+
+        .navbar a.nav-active {
+            color: var(--terracotta);
+            background: rgba(201, 107, 60, 0.08);
+        }
+
+        .navbar a.nav-cta {
+            background: var(--terracotta);
+            color: var(--white);
+            padding: 10px 24px;
+            border-radius: 8px;
+            font-weight: 700;
+        }
+
+        .navbar a.nav-cta:hover {
+            background: var(--terracotta-dark);
+            transform: translateY(-1px);
+            box-shadow: 0 4px 15px var(--glow-orange);
+        }
+
+        /* Page Header */
+        .page-header {
+            padding: 130px 20px 60px;
+            text-align: center;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .page-header::before {
+            content: '';
+            position: absolute;
+            top: -50%;
+            right: -30%;
+            width: 800px;
+            height: 800px;
+            background: radial-gradient(circle, rgba(201, 107, 60, 0.07) 0%, transparent 70%);
+            border-radius: 50%;
+        }
+
+        .page-header::after {
+            content: '';
+            position: absolute;
+            bottom: -30%;
+            left: -20%;
+            width: 600px;
+            height: 600px;
+            background: radial-gradient(circle, rgba(45, 90, 43, 0.05) 0%, transparent 70%);
+            border-radius: 50%;
+        }
+
+        .page-header-content {
+            position: relative;
+            z-index: 2;
+            animation: fadeInUp 0.8s ease-out;
+        }
+
+        @keyframes fadeInUp {
+            from { opacity: 0; transform: translateY(30px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        .event-label {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.14em;
+            color: var(--terracotta);
+            margin-bottom: 14px;
+            display: block;
+        }
+
+        .page-header h1 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: clamp(2.4rem, 5vw, 4rem);
+            font-weight: 700;
+            color: var(--text-dark);
+            margin-bottom: 14px;
+            letter-spacing: -0.03em;
+        }
+
+        .page-header p {
+            font-size: clamp(1rem, 1.8vw, 1.2rem);
+            color: var(--text-light);
+            font-weight: 500;
+            margin-bottom: 6px;
+        }
+
+        /* Day Tabs */
+        .tabs-wrapper {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 20px 70px;
+        }
+
+        .day-tabs {
+            display: flex;
+            gap: 12px;
+            justify-content: center;
+            margin-bottom: 50px;
+        }
+
+        .day-tab {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            padding: 14px 40px;
+            border-radius: 10px;
+            cursor: pointer;
+            border: 2px solid transparent;
+            transition: all 0.3s ease;
+            background: var(--white);
+            color: var(--text-light);
+            border-color: rgba(201, 107, 60, 0.2);
+        }
+
+        .day-tab:hover {
+            border-color: var(--terracotta);
+            color: var(--terracotta);
+        }
+
+        .day-tab.active {
+            background: var(--terracotta);
+            color: var(--white);
+            border-color: var(--terracotta);
+            box-shadow: 0 4px 20px var(--glow-orange);
+        }
+
+        /* Schedule Panel */
+        .schedule-panel {
+            display: none;
+        }
+
+        .schedule-panel.active {
+            display: block;
+            animation: fadeInUp 0.4s ease-out;
+        }
+
+        .day-label {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--warm-brown);
+            text-align: center;
+            margin-bottom: 32px;
+        }
+
+        /* Timeline */
+        .timeline {
+            position: relative;
+        }
+
+        .timeline::before {
+            content: '';
+            position: absolute;
+            left: 110px;
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            background: linear-gradient(180deg, var(--terracotta), var(--gold));
+            opacity: 0.3;
+        }
+
+        .timeline-item {
+            display: flex;
+            gap: 0;
+            margin-bottom: 0;
+            position: relative;
+        }
+
+        .timeline-item:last-child .timeline-connector {
+            display: none;
+        }
+
+        .timeline-time {
+            flex: 0 0 110px;
+            padding-right: 28px;
+            text-align: right;
+            padding-top: 20px;
+        }
+
+        .timeline-time span {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: var(--terracotta);
+            letter-spacing: 0.02em;
+            white-space: nowrap;
+        }
+
+        .timeline-dot-col {
+            flex: 0 0 auto;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding-top: 20px;
+        }
+
+        .timeline-dot {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background: var(--terracotta);
+            border: 2px solid var(--cream);
+            box-shadow: 0 0 0 2px var(--terracotta);
+            flex-shrink: 0;
+            margin-top: 5px;
+            transition: transform 0.2s ease;
+        }
+
+        .timeline-item:hover .timeline-dot {
+            transform: scale(1.3);
+        }
+
+        .timeline-body {
+            flex: 1;
+            padding: 14px 0 14px 28px;
+            border-bottom: 1px solid rgba(201, 107, 60, 0.08);
+            margin-bottom: 0;
+        }
+
+        .timeline-item:last-child .timeline-body {
+            border-bottom: none;
+        }
+
+        .timeline-body h3 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 1.05rem;
+            font-weight: 700;
+            color: var(--text-dark);
+            margin-bottom: 4px;
+            line-height: 1.3;
+        }
+
+        /* Category badges */
+        .timeline-badge {
+            display: inline-block;
+            font-size: 0.7rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            padding: 3px 10px;
+            border-radius: 20px;
+            margin-top: 4px;
+        }
+
+        .badge-social {
+            background: rgba(212, 168, 67, 0.15);
+            color: #9B7620;
+        }
+
+        .badge-content {
+            background: rgba(45, 90, 43, 0.12);
+            color: var(--forest-green);
+        }
+
+        .badge-meal {
+            background: rgba(201, 107, 60, 0.1);
+            color: var(--terracotta-dark);
+        }
+
+        .badge-opening {
+            background: rgba(139, 109, 78, 0.12);
+            color: var(--warm-brown);
+        }
+
+        .badge-workshop {
+            background: rgba(27, 58, 26, 0.12);
+            color: var(--dark-green);
+        }
+
+        /* Section divider for evening */
+        .timeline-section-break {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin: 28px 0 24px 138px;
+        }
+
+        .timeline-section-break span {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: var(--text-light);
+            white-space: nowrap;
+        }
+
+        .timeline-section-break::before,
+        .timeline-section-break::after {
+            content: '';
+            flex: 1;
+            height: 1px;
+            background: rgba(201, 107, 60, 0.15);
+        }
+
+        .timeline-section-break::before {
+            display: none;
+        }
+
+        /* CTA Section */
+        .cta-section {
+            padding: 90px 20px;
+            text-align: center;
+            background: var(--dark-green);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .cta-section::before {
+            content: '';
+            position: absolute;
+            top: -50%;
+            left: -30%;
+            width: 600px;
+            height: 600px;
+            background: radial-gradient(circle, rgba(201, 107, 60, 0.12) 0%, transparent 70%);
+            border-radius: 50%;
+        }
+
+        .cta-content {
+            position: relative;
+            z-index: 1;
+        }
+
+        .cta-content h2 {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: clamp(2rem, 4vw, 3rem);
+            font-weight: 700;
+            color: var(--cream);
+            margin-bottom: 16px;
+            letter-spacing: -0.02em;
+        }
+
+        .cta-content p {
+            font-size: clamp(1rem, 1.8vw, 1.2rem);
+            color: rgba(250, 243, 232, 0.7);
+            margin-bottom: 40px;
+            max-width: 540px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .cta-button {
+            background: var(--terracotta);
+            color: var(--white);
+            padding: 18px 52px;
+            border-radius: 12px;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.1rem;
+            transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+            display: inline-block;
+            font-family: 'Space Grotesk', sans-serif;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            box-shadow: 0 4px 25px rgba(201, 107, 60, 0.4);
+        }
+
+        .cta-button:hover {
+            background: var(--terracotta-light);
+            transform: translateY(-3px) scale(1.03);
+            box-shadow: 0 8px 40px rgba(201, 107, 60, 0.5);
+        }
+
+        /* Footer */
+        .footer {
+            background: var(--text-dark);
+            padding: 40px 20px;
+            text-align: center;
+        }
+
+        .footer p {
+            color: rgba(250, 243, 232, 0.45);
+            font-size: 0.85rem;
+        }
+
+        .footer a {
+            color: rgba(250, 243, 232, 0.6);
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+
+        .footer a:hover {
+            color: var(--terracotta-light);
+        }
+
+        /* Scroll Animations */
+        .fade-in {
+            opacity: 0;
+            transform: translateY(24px);
+            transition: all 0.7s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+        }
+
+        .fade-in.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .navbar-content {
+                gap: 16px;
+                padding: 0 20px;
+            }
+
+            .navbar a {
+                font-size: 0.8rem;
+                padding: 6px 12px;
+            }
+
+            .page-header {
+                padding: 110px 20px 50px;
+            }
+
+            .day-tabs {
+                gap: 10px;
+            }
+
+            .day-tab {
+                padding: 12px 28px;
+                font-size: 0.9rem;
+            }
+
+            .timeline::before {
+                left: 88px;
+            }
+
+            .timeline-time {
+                flex: 0 0 88px;
+                padding-right: 20px;
+            }
+
+            .timeline-time span {
+                font-size: 0.72rem;
+            }
+
+            .timeline-body {
+                padding-left: 20px;
+            }
+
+            .timeline-body h3 {
+                font-size: 0.95rem;
+            }
+
+            .timeline-section-break {
+                margin-left: 108px;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .navbar-content {
+                gap: 8px;
+            }
+
+            .navbar a {
+                font-size: 0.75rem;
+                padding: 5px 8px;
+                letter-spacing: 0.03em;
+            }
+
+            .day-tabs {
+                flex-direction: row;
+                width: 100%;
+            }
+
+            .day-tab {
+                flex: 1;
+                padding: 12px 16px;
+                font-size: 0.82rem;
+            }
+
+            .timeline::before {
+                left: 72px;
+            }
+
+            .timeline-time {
+                flex: 0 0 72px;
+                padding-right: 16px;
+            }
+
+            .timeline-time span {
+                font-size: 0.68rem;
+            }
+
+            .timeline-body {
+                padding-left: 16px;
+            }
+
+            .timeline-section-break {
+                margin-left: 92px;
+            }
+        }
+    </style>
+</head>
+<body>
+
+    <!-- Navbar -->
+    <nav class="navbar" id="navbar">
+        <div class="navbar-content">
+            <a href="/grassroots/26">Home</a>
+            <a href="/grassroots/26#what">About</a>
+            <a href="/grassroots/26#who">Who's Invited</a>
+            <a href="/grassroots/schedule" class="nav-active">Schedule</a>
+            <a href="https://bitcoinpark.com/grassroots" target="_blank" rel="noopener noreferrer" class="nav-cta">Apply</a>
+        </div>
+    </nav>
+
+    <!-- Page Header -->
+    <header class="page-header">
+        <div class="page-header-content fade-in">
+            <span class="event-label">Grassroots Bitcoin 2026 &middot; Nashville, TN</span>
+            <h1>Event Schedule</h1>
+            <p>April 1 &ndash; 2, 2026</p>
+            <p>Bitcoin Park &middot; Nashville, Tennessee</p>
+        </div>
+    </header>
+
+    <!-- Schedule -->
+    <div class="tabs-wrapper fade-in">
+
+        <!-- Day Tabs -->
+        <div class="day-tabs">
+            <button class="day-tab active" data-day="1">Day 1 &mdash; April 1</button>
+            <button class="day-tab" data-day="2">Day 2 &mdash; April 2</button>
+        </div>
+
+        <!-- Day 1 -->
+        <div class="schedule-panel active" id="day1">
+            <p class="day-label">Wednesday, April 1, 2026</p>
+            <div class="timeline">
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>9:00 AM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Doors Open + Breakfast</h3>
+                        <span class="timeline-badge badge-meal">9:00 &ndash; 10:00 AM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>10:00 AM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Welcome Announcement</h3>
+                        <span class="timeline-badge badge-opening">10:00 &ndash; 10:05 AM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>10:05 AM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Room Introductions</h3>
+                        <span class="timeline-badge badge-opening">10:05 &ndash; 10:30 AM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>10:30 AM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Lightning Round Meetup Presentations I</h3>
+                        <span class="timeline-badge badge-content">10:30 AM &ndash; 12:30 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>12:30 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>On Campus Lunch</h3>
+                        <span class="timeline-badge badge-meal">12:30 &ndash; 1:45 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>1:45 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Announcements</h3>
+                        <span class="timeline-badge badge-opening">1:45 &ndash; 2:00 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>2:00 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Lightning Round Meetup Presentations II</h3>
+                        <span class="timeline-badge badge-content">2:00 &ndash; 3:30 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>3:45 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Closing Panel</h3>
+                        <span class="timeline-badge badge-content">3:45 &ndash; 4:15 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-section-break"><span>Evening</span></div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>4:15 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Networking and Cocktail Reception</h3>
+                        <span class="timeline-badge badge-social">4:15 &ndash; 5:30 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>5:30 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Dinner Onsite</h3>
+                        <span class="timeline-badge badge-meal">5:30 &ndash; 7:30 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>7:30 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>After Party</h3>
+                        <span class="timeline-badge badge-social">7:30 &ndash; 9:30 PM</span>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+        <!-- Day 2 -->
+        <div class="schedule-panel" id="day2">
+            <p class="day-label">Thursday, April 2, 2026</p>
+            <div class="timeline">
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>9:00 AM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Doors Open + Breakfast</h3>
+                        <span class="timeline-badge badge-meal">9:00 &ndash; 9:45 AM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>9:45 AM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Welcome Back &amp; Fedi Announcement</h3>
+                        <span class="timeline-badge badge-opening">9:45 &ndash; 10:00 AM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>10:00 AM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Fedi Workshop</h3>
+                        <span class="timeline-badge badge-workshop">10:00 &ndash; 11:30 AM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>11:30 AM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>OpenClaw / Agents / AI Automation</h3>
+                        <span class="timeline-badge badge-workshop">11:30 AM &ndash; 12:30 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>12:30 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>On Campus Lunch</h3>
+                        <span class="timeline-badge badge-meal">12:30 &ndash; 1:30 PM</span>
+                    </div>
+                </div>
+
+                <div class="timeline-item">
+                    <div class="timeline-time"><span>1:30 PM</span></div>
+                    <div class="timeline-dot-col"><div class="timeline-dot"></div></div>
+                    <div class="timeline-body">
+                        <h3>Closing</h3>
+                        <span class="timeline-badge badge-content">1:30 &ndash; 3:00 PM</span>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+    </div>
+
+    <!-- CTA Section -->
+    <section class="cta-section">
+        <div class="cta-content fade-in">
+            <h2>Join Us in Nashville</h2>
+            <p>Space is limited for Bitcoin meetup organizers. Apply today to secure your spot at Grassroots Bitcoin 2026.</p>
+            <a href="https://bitcoinpark.com/grassroots" target="_blank" rel="noopener noreferrer" class="cta-button">Apply Here</a>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <p><a href="https://bitcoinpark.com" target="_blank" rel="noopener noreferrer">Bitcoin Park</a> &middot; Nashville, TN</p>
+    </footer>
+
+    <script>
+        // Navbar scroll effect
+        const navbar = document.getElementById('navbar');
+        window.addEventListener('scroll', () => {
+            navbar.classList.toggle('scrolled', window.scrollY > 50);
+        });
+
+        // Scroll fade-in animations
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) entry.target.classList.add('visible');
+            });
+        }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+
+        document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+
+        // Day tabs
+        const tabs = document.querySelectorAll('.day-tab');
+        const panels = document.querySelectorAll('.schedule-panel');
+
+        tabs.forEach(tab => {
+            tab.addEventListener('click', () => {
+                const day = tab.dataset.day;
+                tabs.forEach(t => t.classList.remove('active'));
+                panels.forEach(p => p.classList.remove('active'));
+                tab.classList.add('active');
+                document.getElementById('day' + day).classList.add('active');
+            });
+        });
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Creates `grassroots/schedule.html` with the full 2-day event schedule, accessible at `bitcoinpark.com/grassroots/schedule`
- Adds a Schedule nav link to the `grassroots/26.html` navbar

## Test plan
- [ ] Visit `bitcoinpark.com/grassroots/26` — confirm Schedule link appears in navbar
- [ ] Visit `bitcoinpark.com/grassroots/schedule` — confirm schedule page loads
- [ ] Verify Day 1 / Day 2 tab switching works
- [ ] Check mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)