### PR TITLE
Fix schedule page: tab disappearing, badge colors, rename

### DIFF
--- a/grassroots/schedule.html
+++ b/grassroots/schedule.html
@@ -346,29 +346,13 @@
             margin-top: 4px;
         }
 
-        .badge-social {
-            background: rgba(212, 168, 67, 0.15);
-            color: #9B7620;
-        }
-
-        .badge-content {
-            background: rgba(45, 90, 43, 0.12);
-            color: var(--forest-green);
-        }
-
-        .badge-meal {
-            background: rgba(201, 107, 60, 0.1);
-            color: var(--terracotta-dark);
-        }
-
-        .badge-opening {
-            background: rgba(139, 109, 78, 0.12);
-            color: var(--warm-brown);
-        }
-
+        .badge-social,
+        .badge-content,
+        .badge-meal,
+        .badge-opening,
         .badge-workshop {
-            background: rgba(27, 58, 26, 0.12);
-            color: var(--dark-green);
+            background: rgba(201, 107, 60, 0.1);
+            color: var(--terracotta);
         }
 
         /* Section divider for evening */
@@ -613,19 +597,19 @@
     <header class="page-header">
         <div class="page-header-content fade-in">
             <span class="event-label">Grassroots Bitcoin 2026 &middot; Nashville, TN</span>
-            <h1>Event Schedule</h1>
+            <h1>Schedule</h1>
             <p>April 1 &ndash; 2, 2026</p>
             <p>Bitcoin Park &middot; Nashville, Tennessee</p>
         </div>
     </header>
 
     <!-- Schedule -->
-    <div class="tabs-wrapper fade-in">
+    <div class="tabs-wrapper">
 
         <!-- Day Tabs -->
         <div class="day-tabs">
-            <button class="day-tab active" data-day="1">Day 1 &mdash; April 1</button>
-            <button class="day-tab" data-day="2">Day 2 &mdash; April 2</button>
+            <button type="button" class="day-tab active" data-day="1">Day 1 &mdash; April 1</button>
+            <button type="button" class="day-tab" data-day="2">Day 2 &mdash; April 2</button>
         </div>
 
         <!-- Day 1 -->


### PR DESCRIPTION
## Summary
- Fixes Day 1/Day 2 tabs disappearing on click (added `type="button"` to prevent default form submit behavior)
- Removed `fade-in` animation from schedule wrapper so content is always visible
- Renamed h1 from "Event Schedule" to "Schedule"
- Unified all time-range badge colors to a single terracotta/amber color

🤖 Generated with [Claude Code](https://claude.com/claude-code)