### PR TITLE
Add Evaluation Criteria to Meetup Kit page

### DIFF
--- a/grassroots/meetupkit.html
+++ b/grassroots/meetupkit.html
@@ -773,6 +773,13 @@
                     [Rod Loom Video]
                 </div>
                 <p>Applications will be reviewed by the teams at Bitcoin Park and Fedi to select the participating meetups.</p>
+
+                <h4 style="margin-top: 28px; font-size: 1.15rem; color: #C96B3C;">Evaluation Criteria</h4>
+                <ol style="margin-top: 12px; padding-left: 24px; line-height: 1.8; color: #555;">
+                    <li><strong>Track Record</strong> — Proof of work showing consistency</li>
+                    <li><strong>Quality</strong> — Event page copy and creativity</li>
+                    <li><strong>Reach</strong> — Attendees and meetup RSVPs</li>
+                </ol>
             </div>
 
             <div class="how-step fade-in">


### PR DESCRIPTION
## Summary
- Adds an **Evaluation Criteria** section within "How It Works" on the Meetup Kit page, directly below the "Applications will be reviewed" text
- Three numbered criteria: Track Record, Quality, Reach

## Test plan
- [ ] Verify the section renders correctly on desktop and mobile
- [ ] Confirm styling matches the existing page aesthetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)